### PR TITLE
Convert Svelte 4 reactive declarations to Svelte 5 runes

### DIFF
--- a/src/lib/components/GenerateTab/components/LevelButton.svelte
+++ b/src/lib/components/GenerateTab/components/LevelButton.svelte
@@ -1,6 +1,7 @@
 <!-- src/lib/components/GenerateTab/ui/LevelSelector/LevelButton.svelte -->
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
+	import { derived } from 'svelte/runes';
 
 	// Props
 	export let level: number;
@@ -27,8 +28,8 @@
 		return colors[level - 1] || colors[0];
 	}
 
-	// Dynamic color
-	$: levelColor = getLevelColor(level);
+	// Dynamic color using derived rune
+	const levelColor = $derived(getLevelColor(level));
 </script>
 
 <button

--- a/src/lib/components/GenerateTab/components/LevelSelector.svelte
+++ b/src/lib/components/GenerateTab/components/LevelSelector.svelte
@@ -2,6 +2,7 @@
 <script lang="ts">
 	import { settingsStore } from '../store/settings';
 	import LevelButton from './LevelButton.svelte';
+	import { derived } from 'svelte/runes';
 
 	// Export the value property for binding
 	export let value: number = 3;
@@ -19,8 +20,8 @@
 		'Expert level with complex combinations'
 	];
 
-	// Current description
-	$: currentDescription = levelDescriptions[value - 1] || levelDescriptions[0];
+	// Current description using derived rune
+	const currentDescription = $derived(levelDescriptions[value - 1] || levelDescriptions[0]);
 
 	// Set level
 	function setLevel(newLevel: number) {

--- a/src/lib/components/GenerateTab/components/PropContinuity.svelte
+++ b/src/lib/components/GenerateTab/components/PropContinuity.svelte
@@ -1,6 +1,7 @@
 <!-- src/lib/components/GenerateTab/ui/PropContinuity.svelte -->
 <script lang="ts">
 	import { settingsStore } from '../store/settings';
+	import { derived } from 'svelte/runes';
 
 	// Export the value property for binding
 	export let value: 'continuous' | 'random' = 'continuous';
@@ -18,8 +19,8 @@
 		settingsStore.setPropContinuity(newValue);
 	}
 
-	// Get current option
-	$: currentOption = continuityOptions.find((opt) => opt.id === value) || continuityOptions[0];
+	// Get current option using derived rune
+	const currentOption = $derived(continuityOptions.find((opt) => opt.id === value) || continuityOptions[0]);
 </script>
 
 <div class="prop-continuity">

--- a/src/lib/components/GenerateTab/components/TurnIntensity.svelte
+++ b/src/lib/components/GenerateTab/components/TurnIntensity.svelte
@@ -3,6 +3,7 @@
 	import { settingsStore } from '../store/settings';
 	import hapticFeedbackService from '$lib/services/HapticFeedbackService';
 	import { browser } from '$app/environment';
+	import { derived } from 'svelte/runes';
 
 	// Export the value property for binding
 	export let value: number = 3;
@@ -14,8 +15,8 @@
 	// Labels for the intensity levels
 	const intensityLabels = ['Minimal', 'Light', 'Moderate', 'Heavy', 'Extreme'];
 
-	// Get current label
-	$: currentLabel = intensityLabels[value - 1] || 'Moderate';
+	// Get current label using derived rune
+	const currentLabel = $derived(intensityLabels[value - 1] || 'Moderate');
 
 	// Update intensity
 	function setIntensity(level: number) {

--- a/src/lib/components/LearnTab/QuizTimer.svelte
+++ b/src/lib/components/LearnTab/QuizTimer.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+	import { derived } from 'svelte/runes';
+
 	export let seconds: number = 60;
 
-	// Format time as MM:SS
-	$: formattedTime = formatTime(seconds);
+	// Format time as MM:SS using derived rune
+	const formattedTime = $derived(formatTime(seconds));
 
 	function formatTime(totalSeconds: number): string {
 		const minutes = Math.floor(totalSeconds / 60);

--- a/src/lib/components/shared/Toast.svelte
+++ b/src/lib/components/shared/Toast.svelte
@@ -3,6 +3,7 @@
 	import { fade, fly } from 'svelte/transition';
 	import hapticFeedbackService from '$lib/services/HapticFeedbackService';
 	import { browser } from '$app/environment';
+	import { derived } from 'svelte/runes';
 
 	export let message: string;
 	export let type: 'success' | 'error' | 'info' | 'warning' = 'info';
@@ -41,8 +42,8 @@
 		}
 	}
 
-	// Get icon based on type
-	$: icon = {
+	// Get icon based on type using derived rune
+	const icon = $derived({
 		success:
 			'<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>',
 		error:
@@ -50,7 +51,7 @@
 		warning:
 			'<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path><line x1="12" y1="9" x2="12" y2="13"></line><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>',
 		info: '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg>'
-	}[type];
+	}[type]);
 </script>
 
 {#if visible}


### PR DESCRIPTION
This PR converts several components from using Svelte 4's reactive declarations (`$:`) to Svelte 5's runes (`$derived`).

### Components converted:

1. **LevelButton.svelte**
   - Converted `$: levelColor = getLevelColor(level);` to `const levelColor = $derived(getLevelColor(level));`

2. **TurnIntensity.svelte**
   - Converted `$: currentLabel = intensityLabels[value - 1] || 'Moderate';` to `const currentLabel = $derived(intensityLabels[value - 1] || 'Moderate');`

3. **PropContinuity.svelte**
   - Converted `$: currentOption = continuityOptions.find((opt) => opt.id === value) || continuityOptions[0];` to `const currentOption = $derived(continuityOptions.find((opt) => opt.id === value) || continuityOptions[0]);`

4. **LevelSelector.svelte**
   - Converted `$: currentDescription = levelDescriptions[value - 1] || levelDescriptions[0];` to `const currentDescription = $derived(levelDescriptions[value - 1] || levelDescriptions[0]);`

5. **Toast.svelte**
   - Converted `$: icon = {...}[type];` to `const icon = $derived({...}[type]);`

6. **QuizTimer.svelte**
   - Converted `$: formattedTime = formatTime(seconds);` to `const formattedTime = $derived(formatTime(seconds));`

### Changes made:

1. Added the `derived` import from 'svelte/runes' to each component
2. Replaced `$:` reactive declarations with `const variableName = $derived(expression);`
3. Maintained the same functionality and behavior in each component

These changes are part of the migration to Svelte 5, focusing on simple cases that are easy to convert.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author